### PR TITLE
RK-6162 - Update libararies for security vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,6 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-
-        // Specific dependencies for fixing different vulnerabilities 
-        classpath("org.hibernate.validator:hibernate-validator:6.1.1.Final")
-        classpath("org.springframework:spring-webmvc:5.2.3.RELEASE")
-        classpath("org.apache.tomcat.embed:tomcat-embed-core:9.0.30")
-
     }
 }
 
@@ -43,6 +37,14 @@ repositories {
 dependencies {
     compile('io.joshworks.unirest:unirest-java:1.6.0')
     compile('org.springframework.boot:spring-boot-starter-web')
+
+    // Specific dependencies for fixing different vulnerabilities
+    compile("org.hibernate.validator:hibernate-validator:6.1.3.Final")
+    compile("org.springframework:spring-webmvc:5.2.6.RELEASE")
+    compile("org.springframework:spring-web:5.2.6.RELEASE")
+    compile("org.apache.tomcat.embed:tomcat-embed-core:9.0.35")
+    compile("org.yaml:snakeyaml:1.26")
+
     testCompile('org.springframework.boot:spring-boot-starter-test')
     testCompile('org.springframework.restdocs:spring-restdocs-mockmvc')
 }


### PR DESCRIPTION
Last time I added the new libraries under buildScript which was wrong, since this scope is for the dependencies of the gradle script itself.

https://gradle.org/books/packt-gradle-dependency-management.pdf
