### PR TITLE
upgrade six for google

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ references:
       command: |
         mkdir -p ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
         sudo apt update && sudo apt-get install python3 python3-setuptools python3-dev build-essential libpq-dev libffi6 libffi-dev libssl-dev python3-pip
-        python3 -m pip install --upgrade --user setuptools
+        python3 -m pip install --upgrade --user setuptools six
         git clone git@github.com:Rookout/build_tools.git
         cd build_tools
         python3 -m pip install -r requirements.txt --user


### PR DESCRIPTION
Old docker image uses an old six.
Too much red
![image](https://user-images.githubusercontent.com/31986166/97217410-e7d38400-17cf-11eb-9da5-0da8febf3589.png)

